### PR TITLE
fix(pom): export impl packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
           <configuration>
             <instructions>
               <Export-Package>
-                !*impl*,
                 org.camunda.connect*
               </Export-Package>
             </instructions>


### PR DESCRIPTION
-change configuration for maven-bundle-plugin because
http-client and soap-http-client use the impl package
from core and soap-http-client uses the impl
package from http-client, so they have to be exported