### PR TITLE
feat(connect): extend request with configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ camunda-connect
 ===============
 
 <p>
-  <a href="http://camunda.org/">Home</a> |
-  <a href="http://docs.camunda.org/latest/api-references/connect/">Documentation</a> |
-  <a href="http://camunda.org/community/forum.html">Forum</a> |
-  <a href="https://app.camunda.com/jira/browse/CAM">Issues</a> |
+  <a href="http://camunda.com/">Home</a> |
+  <a href="https://docs.camunda.org/manual/latest/reference/connect/">Documentation</a> |
+  <a href="https://forum.camunda.org/">Forum</a> |
+  <a href="https://jira.camunda.com/browse/CAM">Issues</a> |
   <a href="LICENSE">License</a> |
   <a href="CONTRIBUTING.md">Contribute</a>
 </p>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -49,6 +49,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/http-client/src/main/java/org/camunda/connect/httpclient/HttpBaseRequest.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/HttpBaseRequest.java
@@ -29,6 +29,8 @@ public interface HttpBaseRequest<Q extends HttpBaseRequest<?, ?>, R extends Conn
   String PARAM_NAME_REQUEST_PAYLOAD = "payload";
   String HEADER_CONTENT_TYPE = "Content-Type";
 
+  String PARAM_NAME_REQUEST_CONFIG = "request-config";
+
   /**
    * Set the url of this request.
    *
@@ -99,4 +101,23 @@ public interface HttpBaseRequest<Q extends HttpBaseRequest<?, ?>, R extends Conn
    * @return the method of this request or null if not set
    */
   String getMethod();
+
+  /**
+   * @return the HTTP configuration options of this request or null if non set
+   */
+  Map<String, Object> getConfigOptions();
+
+  /**
+   * @return the HTTP configuration option value of this request or null if non set
+   */
+  Object getConfigOption(String field);
+
+  /**
+   * Set a HTTP request configuration option for this request.
+   *
+   * @param field HTTP request configuration name
+   * @param value HTTP request configuration value
+   * @return this request
+   */
+  Q configOption(String field, Object value);
 }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
@@ -20,6 +20,8 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
 import java.util.Map;
 
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.config.RequestConfig.Builder;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
@@ -36,6 +38,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.camunda.connect.httpclient.HttpBaseRequest;
 import org.camunda.connect.httpclient.HttpResponse;
+import org.camunda.connect.httpclient.impl.util.ParseUtil;
 import org.camunda.connect.impl.AbstractConnector;
 
 public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R extends HttpResponse> extends AbstractConnector<Q, R> {
@@ -90,6 +93,8 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
    */
   protected <T extends HttpRequestBase> T createHttpRequest(Q request) {
     T httpRequest = createHttpRequestBase(request);
+
+    applyConfig(httpRequest, request.getConfigOptions());
 
     applyHeaders(httpRequest, request.getHeaders());
 
@@ -154,5 +159,15 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
   protected <T extends HttpRequestBase> boolean httpMethodSupportsPayload(T httpRequest) {
     return httpRequest instanceof HttpEntityEnclosingRequestBase;
   }
+
+  protected <T extends HttpRequestBase> void applyConfig(T httpRequest, Map<String, Object> configOptions) {
+    Builder configBuilder = RequestConfig.custom();
+    if (configOptions != null && !configOptions.isEmpty()) {
+      ParseUtil.parseConfigOptions(configOptions, configBuilder);
+    }
+    RequestConfig requestConfig = configBuilder.build();
+    httpRequest.setConfig(requestConfig);
+  }
+
 
 }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
@@ -142,4 +142,33 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
     return method(HttpTrace.METHOD_NAME);
   }
 
+
+  public Map<String, Object> getConfigOptions() {
+    return getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_CONFIG);
+  }
+
+  public Object getConfigOption(String field) {
+    Map<String, Object> config = getConfigOptions();
+    if (config != null) {
+      return config.get(field);
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Q configOption(String field, Object value) {
+    if (field == null || field.isEmpty() || value == null) {
+      LOG.ignoreConfig(field, value);
+    } else {
+      Map<String, Object> config = getConfigOptions();
+
+      if (config == null) {
+        config = new HashMap<String, Object>();
+        setRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_CONFIG, config);
+      }
+      config.put(field, value);
+    }
+
+    return (Q) this;
+  }
 }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
@@ -51,4 +51,12 @@ public class HttpConnectorLogger extends ConnectLogger {
     return new ConnectorRequestException(exceptionMessage("007", "Unable to execute HTTP request"), cause);
   }
 
+  public ConnectorRequestException invalidConfigurationOption(String optionName, Exception cause) {
+    return new ConnectorRequestException(exceptionMessage("008", "Invalid value for request configuration option: {}", optionName), cause);
+  }
+
+  public void ignoreConfig(String field, Object value) {
+    logInfo("009", "Ignoring request configuration option with name '{}' and value '{}'", field, value);
+  }
+
 }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/RequestConfigOption.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/RequestConfigOption.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.connect.httpclient.impl;
+
+import java.net.InetAddress;
+import java.util.Collection;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig.Builder;
+
+public enum RequestConfigOption {
+
+  AUTHENTICATION_ENABLED("authentication-enabled") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setAuthenticationEnabled((boolean) value);
+    }
+  },
+  CIRCULAR_REDIRECTS_ALLOWED("circular-redirects-allowed") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setCircularRedirectsAllowed((boolean) value);
+    }
+  },
+  CONNECTION_TIMEOUT("connection-timeout") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setConnectTimeout((int) value);
+    }
+  },
+  CONNECTION_REQUEST_TIMEOUT("connection-request-timeout") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setConnectionRequestTimeout((int) value);
+    }
+  },
+  CONTENT_COMPRESSION_ENABLED("content-compression-enabled") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setContentCompressionEnabled((boolean) value);
+    }
+  },
+  COOKIE_SPEC("cookie-spec") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setCookieSpec((String) value);
+    }
+  },
+  DECOMPRESSION_ENABLED("decompression-enabled") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setDecompressionEnabled((boolean) value);
+    }
+  },
+  EXPECT_CONTINUE_ENABLED("expect-continue-enabled") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setExpectContinueEnabled((boolean) value);
+    }
+  },
+  LOCAL_ADDRESS("local-address") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setLocalAddress((InetAddress) value);
+    }
+  },
+  MAX_REDIRECTS("max-redirects") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setMaxRedirects((int) value);
+    }
+  },
+  PROXY("proxy") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setProxy((HttpHost) value);
+    }
+  },
+  PROXY_PREFERRED_AUTH_SCHEMES("proxy-preferred-auth-scheme") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setProxyPreferredAuthSchemes((Collection<String>) value);
+    }
+  },
+  REDIRECTS_ENABLED("relative-redirects-allowed") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setRedirectsEnabled((boolean) value);
+    }
+  },
+  RELATIVE_REDIRECTS_ALLOWED("relative-redirects-allowed") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setRelativeRedirectsAllowed((boolean) value);
+    }
+  },
+  SOCKET_TIMEOUT("socket-timeout") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setSocketTimeout((int) value);
+    }
+  },
+  STALE_CONNECTION_CHECK_ENABLED("stale-connection-check-enabled") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setStaleConnectionCheckEnabled((boolean) value);
+    }
+  },
+  TARGET_PREFERRED_AUTH_SCHEMES("target-preferred-auth-schemes") {
+    @Override
+    public void apply(Builder configBuilder, Object value) {
+      configBuilder.setTargetPreferredAuthSchemes((Collection<String>) value);
+    }
+  };
+
+  private String name;
+
+  private RequestConfigOption(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public abstract void apply(Builder configBuilder, Object value);
+}

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/util/ParseUtil.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/util/ParseUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.connect.httpclient.impl.util;
+
+import java.util.Map;
+
+import org.apache.http.client.config.RequestConfig.Builder;
+import org.camunda.connect.httpclient.impl.RequestConfigOption;
+import org.camunda.connect.httpclient.impl.HttpConnectorLogger;
+import org.camunda.connect.httpclient.impl.HttpLogger;
+
+public class ParseUtil {
+
+  protected static HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+
+  public static void parseConfigOptions(Map<String, Object> configOptions, Builder configBuilder) {
+    for (RequestConfigOption option : RequestConfigOption.values()) {
+      try {
+        if (configOptions.containsKey(option.getName())) {
+          option.apply(configBuilder, configOptions.get(option.getName()));
+        }
+      } catch (ClassCastException e) {
+        throw LOG.invalidConfigurationOption(option.getName(), e);
+      }
+    }
+  }
+
+}

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestConfigTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestConfigTest.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.connect.httpclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.AUTHENTICATION_ENABLED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.CIRCULAR_REDIRECTS_ALLOWED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.CONNECTION_REQUEST_TIMEOUT;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.CONNECTION_TIMEOUT;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.CONTENT_COMPRESSION_ENABLED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.COOKIE_SPEC;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.DECOMPRESSION_ENABLED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.EXPECT_CONTINUE_ENABLED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.LOCAL_ADDRESS;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.MAX_REDIRECTS;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.PROXY;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.PROXY_PREFERRED_AUTH_SCHEMES;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.REDIRECTS_ENABLED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.RELATIVE_REDIRECTS_ALLOWED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.SOCKET_TIMEOUT;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.STALE_CONNECTION_CHECK_ENABLED;
+import static org.camunda.connect.httpclient.impl.RequestConfigOption.TARGET_PREFERRED_AUTH_SCHEMES;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.camunda.connect.ConnectorRequestException;
+import org.camunda.connect.httpclient.impl.HttpConnectorImpl;
+import org.camunda.connect.httpclient.impl.util.ParseUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+
+public class HttpRequestConfigTest {
+
+  public static final String EXAMPLE_URL = "http://camunda.org/example";
+  public static final String EXAMPLE_CONTENT_TYPE = "application/json";
+  public static final String EXAMPLE_PAYLOAD = "camunda";
+
+  protected HttpConnector connector;
+
+  @Before
+  public void createConnector() {
+    connector = new HttpConnectorImpl();
+  }
+
+  @Test
+  public void shouldParseAuthenticationEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(AUTHENTICATION_ENABLED.getName(), false);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isAuthenticationEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldParseCircularRedirectsAllowed() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(CIRCULAR_REDIRECTS_ALLOWED.getName(), true);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isCircularRedirectsAllowed()).isTrue();
+  }
+
+  @Test
+  public void shouldParseConnectionTimeout() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(CONNECTION_TIMEOUT.getName(), -2);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getConnectTimeout()).isEqualTo(-2);
+  }
+
+  @Test
+  public void shouldParseConnectionRequestTimeout() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(CONNECTION_REQUEST_TIMEOUT.getName(), -2);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getConnectionRequestTimeout()).isEqualTo(-2);
+  }
+
+  @Test
+  public void shouldParseContentCompressionEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(CONTENT_COMPRESSION_ENABLED.getName(), false);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isContentCompressionEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldParseCookieSpec() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(COOKIE_SPEC.getName(), "test");
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getCookieSpec()).isEqualTo("test");
+  }
+
+  @Test
+  public void shouldParseDecompressionEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(DECOMPRESSION_ENABLED.getName(), false);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isDecompressionEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldParseExpectContinueEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(EXPECT_CONTINUE_ENABLED.getName(), true);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isExpectContinueEnabled()).isTrue();
+  }
+
+  @Test
+  public void shouldParseLocalAddress() throws UnknownHostException {
+    // given
+    InetAddress testAddress = InetAddress.getByName("127.0.0.1");
+    HttpRequest request = connector.createRequest()
+        .configOption(LOCAL_ADDRESS.getName(), testAddress);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getLocalAddress()).isEqualTo(testAddress);
+  }
+
+  @Test
+  public void shouldParseMaxRedirects() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(MAX_REDIRECTS.getName(), -2);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getMaxRedirects()).isEqualTo(-2);
+  }
+
+  @Test
+  public void shouldParseProxy() {
+    // given
+    HttpHost testHost = new HttpHost("test");
+    HttpRequest request = connector.createRequest()
+        .configOption(PROXY.getName(), testHost);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getProxy()).isEqualTo(testHost);
+  }
+
+  @Test
+  public void shouldParseProxyPreferredAuthSchemes() {
+    // given
+    ArrayList<String> testArray = new ArrayList<String>();
+    HttpRequest request = connector.createRequest()
+        .configOption(PROXY_PREFERRED_AUTH_SCHEMES.getName(), testArray);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getProxyPreferredAuthSchemes()).isEqualTo(testArray);
+  }
+
+  @Test
+  public void shouldParseRedirectsEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(REDIRECTS_ENABLED.getName(), false);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isRedirectsEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldParseRelativeRedirectsAllowed() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(RELATIVE_REDIRECTS_ALLOWED.getName(), false);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isRelativeRedirectsAllowed()).isFalse();
+  }
+
+
+  @Test
+  public void shouldParseSocketTimeout() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(SOCKET_TIMEOUT.getName(), -2);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getSocketTimeout()).isEqualTo(-2);
+  }
+
+
+  @Test
+  public void shouldParseStaleConnectionCheckEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(STALE_CONNECTION_CHECK_ENABLED.getName(), true);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isStaleConnectionCheckEnabled()).isTrue();
+  }
+
+
+  @Test
+  public void shouldParseTargetPreferredAuthSchemes() {
+    // given
+    ArrayList<String> testArray = new ArrayList<String>();
+    HttpRequest request = connector.createRequest()
+        .configOption(TARGET_PREFERRED_AUTH_SCHEMES.getName(), testArray);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getTargetPreferredAuthSchemes()).isEqualTo(testArray);
+  }
+
+  @Test
+  public void shouldNotChangeDefaultConfig() {
+    // given
+    HttpClient client = (HttpClient) Whitebox.getInternalState(connector, "httpClient");
+    connector.createRequest().url(EXAMPLE_URL).get()
+        .configOption(CONNECTION_TIMEOUT.getName(), -2)
+        .configOption(SOCKET_TIMEOUT.getName(), -2)
+        .configOption(CONNECTION_REQUEST_TIMEOUT.getName(), -2)
+        .configOption(MAX_REDIRECTS.getName(), 0)
+        .execute();
+
+    // when
+    RequestConfig config = (RequestConfig) Whitebox.getInternalState(client, "defaultConfig");
+
+    // then
+    assertThat(config.getMaxRedirects()).isEqualTo(50);
+    assertThat(config.getConnectTimeout()).isEqualTo(-1);
+    assertThat(config.getConnectionRequestTimeout()).isEqualTo(-1);
+    assertThat(config.getSocketTimeout()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldThrowTimeoutException() {
+    try {
+      // when
+      connector.createRequest().url(EXAMPLE_URL).get()
+          .configOption(CONNECTION_TIMEOUT.getName(), 1)
+          .execute();
+    } catch (ConnectorRequestException e) {
+      // then
+      assertThat(e).hasMessageContaining("Unable to execute HTTP request");
+      assertThat(e).hasCauseExactlyInstanceOf(ConnectTimeoutException.class);
+    }
+  }
+
+  @Test
+  public void shouldThrowClassCastExceptionStringToInt() {
+    try {
+      // when
+      connector.createRequest().url(EXAMPLE_URL).get()
+          .configOption(CONNECTION_TIMEOUT.getName(), "-1")
+          .execute();
+    } catch (ConnectorRequestException e) {
+      // then
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + CONNECTION_TIMEOUT.getName());
+      assertThat(e.getCause()).hasMessage("java.lang.String cannot be cast to java.lang.Integer");
+      assertThat(e).hasCauseInstanceOf(ClassCastException.class);
+    }
+  }
+
+  @Test
+  public void shouldThrowClassCastExceptionStringToBoolean() {
+    try {
+      // when
+      connector.createRequest().url(EXAMPLE_URL).get()
+          .configOption(AUTHENTICATION_ENABLED.getName(), "true")
+          .execute();
+    } catch (ConnectorRequestException e) {
+      // then
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + AUTHENTICATION_ENABLED.getName());
+      assertThat(e.getCause()).hasMessage("java.lang.String cannot be cast to java.lang.Boolean");
+      assertThat(e).hasCauseInstanceOf(ClassCastException.class);
+    }
+  }
+
+  @Test
+  public void shouldThrowClassCastExceptionStringToHttpHost() {
+    try {
+      // when
+      connector.createRequest().url(EXAMPLE_URL).get()
+      .configOption(PROXY.getName(), "proxy")
+      .execute();
+    } catch (ConnectorRequestException e) {
+      // then
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + PROXY.getName());
+      assertThat(e.getCause()).hasMessage("java.lang.String cannot be cast to org.apache.http.HttpHost");
+      assertThat(e).hasCauseInstanceOf(ClassCastException.class);
+    }
+  }
+
+  @Test
+  public void shouldThrowClassCastExceptionIntToHttpHost() {
+    try {
+      // when
+      connector.createRequest().url(EXAMPLE_URL).get()
+      .configOption(PROXY_PREFERRED_AUTH_SCHEMES.getName(), 0)
+      .execute();
+    } catch (ConnectorRequestException e) {
+      // then
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + PROXY_PREFERRED_AUTH_SCHEMES.getName());
+      assertThat(e.getCause()).hasMessage("java.lang.Integer cannot be cast to java.util.Collection");
+      assertThat(e).hasCauseInstanceOf(ClassCastException.class);
+    }
+  }
+
+}

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestTest.java
@@ -160,4 +160,35 @@ public class HttpRequestTest {
       .containsEntry("number", 42);
   }
 
+  @Test
+  public void setConfigOption() {
+    Object value = new Object();
+    HttpRequest request = connector.createRequest()
+        .configOption("object-field", value)
+        .configOption("int-field", 15)
+        .configOption("long-field", 15l)
+        .configOption("boolean-field", true)
+        .configOption("string-field", "string-value");
+
+    assertThat(request.getConfigOption("object-field")).isEqualTo(value);
+    assertThat(request.getConfigOption("int-field")).isEqualTo(15);
+    assertThat(request.getConfigOption("long-field")).isEqualTo(15l);
+    assertThat(request.getConfigOption("boolean-field")).isEqualTo(true);
+    assertThat(request.getConfigOption("string-field")).isEqualTo("string-value");
+  }
+
+  @Test
+  public void shouldIgnoreConfigWithNullOrEmptyNameOrNullValue() {
+      HttpRequest request = connector.createRequest();
+
+      request.configOption(null, "test");
+      assertThat(request.getConfigOptions()).isNull();
+
+      request.configOption("", "test");
+      assertThat(request.getConfigOptions()).isNull();
+
+      request.configOption("test", null);
+      assertThat(request.getConfigOptions()).isNull();
+  }
+
 }


### PR DESCRIPTION
cherry-picked from 7213de2aa001b8ad5c942ad82f0a883376d2efae, CAM-12458

+ make test jdk 7 complaint
+ remove normalizeUri option not supported in httpclient 4.5.7 used in
1.1 connect

Related to CAM-12468