### PR TITLE
CAM-12774: override commons-codec in connector module

### DIFF
--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -23,6 +23,13 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
+    <!-- commons-codec is a transitive dependency of httpclient;
+      we override its version here in order to update the default commons-codec
+      version which has known vulnerabilities, see https://jira.camunda.com/browse/CAM-12774 -->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,7 @@
         <artifactId>httpclient</artifactId>
         <version>4.5.13</version>
       </dependency>
-      <!-- commons-codec is a transitive dependency of httpclient;
-        we override its version here in order to update the default commons-codec
-        version which has known vulnerabilities, see https://jira.camunda.com/browse/CAM-12774 -->
+      
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>


### PR DESCRIPTION
- it's not sufficient to override the version in dependencyManagement of the
  root pom; this worked in the shaded all jar (I assume because it inherits
  root's dependencyManagement section), but not in modules where
  the regular http-connector is consumed as a dependency (e.g. wildfly modules
  in platform); these modules still got the old commons-codec version

related to CAM-12774