### PR TITLE
feat (connect-http-client):  add query parameters

### DIFF
--- a/http-client/src/main/java/org/camunda/connect/httpclient/HttpBaseRequest.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/HttpBaseRequest.java
@@ -122,19 +122,19 @@ public interface HttpBaseRequest<Q extends HttpBaseRequest<?, ?>, R extends Conn
    * @param value HTTP query value
    * @return this request
    */
-  Q query(String field, String value);
+  Q query(String field, Object value);
 
   /**
    *
    * @return the HTTP Query parameters of this request or null if non set
    */
-  Map<String,String> getQueryParameters();
+  Map<String,Object> getQueryParameters();
 
   /**
    *
    * @return the HTTP Query parameter value of this request or null if non set
    */
-  String getQueryParameter(String field);
+  Object getQueryParameter(String field);
 
   /**
    * Set a HTTP request configuration option for this request.

--- a/http-client/src/main/java/org/camunda/connect/httpclient/HttpBaseRequest.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/HttpBaseRequest.java
@@ -31,6 +31,8 @@ public interface HttpBaseRequest<Q extends HttpBaseRequest<?, ?>, R extends Conn
 
   String PARAM_NAME_REQUEST_CONFIG = "request-config";
 
+  String PARAM_NAME_REQUEST_QUERY = "query";
+
   /**
    * Set the url of this request.
    *
@@ -111,6 +113,28 @@ public interface HttpBaseRequest<Q extends HttpBaseRequest<?, ?>, R extends Conn
    * @return the HTTP configuration option value of this request or null if non set
    */
   Object getConfigOption(String field);
+
+
+  /**
+   * Set a HTTP query parameter for this request.
+   *
+   * @param field HTTP query field
+   * @param value HTTP query value
+   * @return this request
+   */
+  Q query(String field, String value);
+
+  /**
+   *
+   * @return the HTTP Query parameters of this request or null if non set
+   */
+  Map<String,String> getQueryParameters();
+
+  /**
+   *
+   * @return the HTTP Query parameter value of this request or null if non set
+   */
+  String getQueryParameter(String field);
 
   /**
    * Set a HTTP request configuration option for this request.

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
@@ -173,11 +173,11 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     httpRequest.setConfig(requestConfig);
   }
 
-  protected <T extends HttpRequestBase> void applyQueryParameters(T httpRequest, Map<String, String> queryParameters) {
+  protected <T extends HttpRequestBase> void applyQueryParameters(T httpRequest, Map<String, Object> queryParameters) {
     if (queryParameters != null && !queryParameters.isEmpty()) {
       URIBuilder uriBuilder = new URIBuilder(httpRequest.getURI());
-      for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
-        uriBuilder.addParameter(entry.getKey(), entry.getValue());
+      for (Map.Entry<String, Object> entry : queryParameters.entrySet()) {
+        uriBuilder.addParameter(entry.getKey(), entry.getValue().toString());
       }
       try {
         httpRequest.setURI(uriBuilder.build());

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
@@ -17,6 +17,7 @@
 package org.camunda.connect.httpclient.impl;
 
 import java.io.ByteArrayInputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.Map;
 
@@ -33,6 +34,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -99,6 +101,8 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     applyHeaders(httpRequest, request.getHeaders());
 
     applyPayload(httpRequest, request);
+
+    applyQueryParameters(httpRequest, request.getQueryParameters());
 
     return httpRequest;
   }
@@ -167,6 +171,21 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     }
     RequestConfig requestConfig = configBuilder.build();
     httpRequest.setConfig(requestConfig);
+  }
+
+  protected <T extends HttpRequestBase> void applyQueryParameters(T httpRequest, Map<String, String> queryParameters) {
+    if (queryParameters != null && !queryParameters.isEmpty()) {
+      URIBuilder uriBuilder = new URIBuilder(httpRequest.getURI());
+      for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
+        uriBuilder.addParameter(entry.getKey(), entry.getValue());
+      }
+      try {
+        httpRequest.setURI(uriBuilder.build());
+      } catch (URISyntaxException e) {
+        // should never happen
+        throw new IllegalArgumentException(e.getMessage(), e);
+      }
+    }
   }
 
 

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
@@ -156,6 +156,36 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
   }
 
   @SuppressWarnings("unchecked")
+  public Q query(String field, String value) {
+    if (field == null || field.isEmpty() || value == null || value.isEmpty()) {
+      LOG.ignoreQueryParameter(field, value);
+    } else {
+      Map<String, String> queries = getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_QUERY);
+
+      if (queries == null) {
+        queries = new HashMap<>();
+        setRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_QUERY, queries);
+      }
+      queries.put(field, value);
+    }
+
+    return (Q) this;
+  }
+
+  public Map<String, String> getQueryParameters() {
+    return getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_QUERY);
+  }
+
+  public String getQueryParameter(String field) {
+    Map<String, String> query = getQueryParameters();
+    if (query != null) {
+      return query.get(field);
+    }
+    return null;
+  }
+
+
+  @SuppressWarnings("unchecked")
   public Q configOption(String field, Object value) {
     if (field == null || field.isEmpty() || value == null) {
       LOG.ignoreConfig(field, value);

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
@@ -156,11 +156,11 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
   }
 
   @SuppressWarnings("unchecked")
-  public Q query(String field, String value) {
-    if (field == null || field.isEmpty() || value == null || value.isEmpty()) {
+  public Q query(String field, Object value) {
+    if (field == null || field.isEmpty() || value == null || value.toString().isEmpty()) {
       LOG.ignoreQueryParameter(field, value);
     } else {
-      Map<String, String> queries = getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_QUERY);
+      Map<String, Object> queries = getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_QUERY);
 
       if (queries == null) {
         queries = new HashMap<>();
@@ -172,12 +172,12 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
     return (Q) this;
   }
 
-  public Map<String, String> getQueryParameters() {
+  public Map<String, Object> getQueryParameters() {
     return getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_QUERY);
   }
 
-  public String getQueryParameter(String field) {
-    Map<String, String> query = getQueryParameters();
+  public Object getQueryParameter(String field) {
+    Map<String, Object> query = getQueryParameters();
     if (query != null) {
       return query.get(field);
     }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
@@ -59,4 +59,8 @@ public class HttpConnectorLogger extends ConnectLogger {
     logInfo("009", "Ignoring request configuration option with name '{}' and value '{}'", field, value);
   }
 
+  public void ignoreQueryParameter(String field, String value) {
+    logInfo("010", "Ignoring query parameter with name '{}' and value '{}'", field, value);
+  }
+
 }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
@@ -59,7 +59,7 @@ public class HttpConnectorLogger extends ConnectLogger {
     logInfo("009", "Ignoring request configuration option with name '{}' and value '{}'", field, value);
   }
 
-  public void ignoreQueryParameter(String field, String value) {
+  public void ignoreQueryParameter(String field, Object value) {
     logInfo("010", "Ignoring query parameter with name '{}' and value '{}'", field, value);
   }
 

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorTest.java
@@ -180,6 +180,14 @@ public class HttpConnectorTest {
     HttpGet request = interceptor.getTarget();
     assertThat(request.getURI().getQuery()).isEqualTo("foo=bar&hello=world");
   }
+
+  @Test
+  public void shouldCastString(){
+    connector.createRequest().url(EXAMPLE_URL).query("foo", 1).query("hello",12.12).get().execute();
+    HttpGet request = interceptor.getTarget();
+    assertThat(request.getURI().getQuery()).isEqualTo("foo=1&hello=12.12");
+  }
+
   @Test
   public void shouldSetEncodeQueries(){
     connector.createRequest().url(EXAMPLE_URL).query("foo", "bar bar").query("hello", "world world").get().execute();

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorTest.java
@@ -174,6 +174,19 @@ public class HttpConnectorTest {
     assertThat(contentLength).isEqualTo(EXAMPLE_PAYLOAD.length());
   }
 
+  @Test
+  public void shouldSetQueries(){
+    connector.createRequest().url(EXAMPLE_URL).query("foo", "bar").query("hello", "world").get().execute();
+    HttpGet request = interceptor.getTarget();
+    assertThat(request.getURI().getQuery()).isEqualTo("foo=bar&hello=world");
+  }
+  @Test
+  public void shouldSetEncodeQueries(){
+    connector.createRequest().url(EXAMPLE_URL).query("foo", "bar bar").query("hello", "world world").get().execute();
+    HttpGet request = interceptor.getTarget();
+    assertThat(request.getURI().getQuery()).isEqualTo("foo=bar+bar&hello=world+world");
+  }
+
   protected void verifyHttpRequest(Class<? extends HttpRequestBase> requestClass) {
     Object target = interceptor.getTarget();
     assertThat(target).isInstanceOf(requestClass);

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestTest.java
@@ -191,4 +191,37 @@ public class HttpRequestTest {
       assertThat(request.getConfigOptions()).isNull();
   }
 
+  @Test
+  public void setQueryParams() {
+    HttpRequest request = connector.createRequest().get();
+    request.query("foo", "bar");
+    request.query("hello", "world");
+
+    assertThat(request.getQueryParameters())
+            .hasSize(2)
+            .containsEntry("foo", "bar")
+            .containsEntry("hello", "world");
+
+
+    assertThat(request.getQueryParameter("hello")).isEqualTo("world");
+    assertThat(request.getQueryParameter("unknown")).isNull();
+  }
+
+  @Test
+  public void shouldIgnoreQueryParamsWithNullOrEmptyNameOrValue() {
+    HttpRequest request = connector.createRequest().get();
+
+    request.query(null, "test");
+    assertThat(request.getQueryParameters()).isNull();
+
+    request.query("", "test");
+    assertThat(request.getQueryParameters()).isNull();
+
+    request.query("test", null);
+    assertThat(request.getQueryParameters()).isNull();
+
+    request.query("test", "");
+    assertThat(request.getQueryParameters()).isNull();
+  }
+
 }


### PR DESCRIPTION
sometimes we should add query params to the url.

I didn't find any way to do that except to concatenate urls.

so i add the query method  and query  request parameter.

----

i think it's useful in the camunda-modeler

e.g.
i have variables map like this :
```json
{
  "name" : "hello world",
  "age" : 12
}
```

and then i would like to use this variables in the http-connector.

before add  query request parameter, i should add url inputParameter like this
```xml
<camunda:inputParameter name="url">
  https://camunda.com/example?name=#{name}&age=#{age}
</camunda:inputParameter>
```

but it will throw a exception , becase the variable `name` has a space in it 

after add  query request parameter, i should add `url` inputParameter and `query`inputParameter like this
```xml
  <camunda:inputParameter name="url">
    https://camunda.com/example
  </camunda:inputParameter>
  <camunda:inputParameter name="query">
  <camunda:map>
    <camunda:entry key="age">#{age}</camunda:entry>
    <camunda:entry key="name">#{name}</camunda:entry>
  </camunda:map>
```

and it's will work ok


