### PR TITLE
chore(deps): exclude commons-logging from shaded jar

### DIFF
--- a/connectors-all/pom.xml
+++ b/connectors-all/pom.xml
@@ -47,6 +47,7 @@
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <excludes>
+                  <exclude>commons-logging:commons-logging</exclude>
                   <exclude>org.camunda.commons:*</exclude>
                   <exclude>org.camunda.connect:camunda-connect-core</exclude>
                   <exclude>org.slf4j:*</exclude>


### PR DESCRIPTION
Context: https://github.com/camunda/camunda-bpm-platform/issues/3673

This changes excludes `commons-logging` from the shaded `camunda-connect-connectors-all` jar.
The dependencey is initially declared by `org.apache.httpcomponents:httpclient` through `camunda-connect-http-client`. 
On further investigation there seems to be no need for it to be included during runtime.

On a side-note: 
This repo seems pretty out-dated in terms of dependency versions. 
Is there a general interest in upgrading those by adding renovate / dependabot to this repo?
Additionally, is there any interest in a `httpclient5` implementation? I'd be happy to look into it.