### PR TITLE
feat(connect): upgrade to apache httpclient 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,30 @@ camunda-connect
 ===============
 
 <p>
-  <a href="http://camunda.com/">Home</a> |
+  <a href="https://camunda.com/">Home</a> |
   <a href="https://docs.camunda.org/manual/latest/reference/connect/">Documentation</a> |
   <a href="https://forum.camunda.org/">Forum</a> |
   <a href="https://jira.camunda.com/browse/CAM">Issues</a> |
   <a href="LICENSE">License</a> |
-  <a href="CONTRIBUTING.md">Contribute</a>
+  <a href="https://github.com/camunda/camunda-bpm-platform/blob/master/CONTRIBUTING.md">Contribute</a>
 </p>
 
 Simple API for connecting HTTP Services and other things.
 
-# List of connectors
+# List of Connectors
 
-* HTTP Connector
-* SOAP HTTP Connector
+* HTTP Connector (using Apache HttpClient 5.x)
+* SOAP HTTP Connector (using Apache HttpClient 5.x)
 
 # Using a Connector
 
-camunda Connect API aims at two usage scenarios, usage in a generic system such as Camunda Platform
+Camunda Connect API aims at two usage scenarios, usage in a generic system such as Camunda Platform
 process engine and standalone usage via API. Please see the [official documentation](https://docs.camunda.org/manual/latest/reference/connect/) for more information.
 
 # Contributing
 
 Have a look at our [contribution guide](https://github.com/camunda/camunda-bpm-platform/blob/master/CONTRIBUTING.md) for how to contribute to this repository.
 
-
-# License:
+# License
 
 The source files in this repository are made available under the <a href="LICENSE">Apache License, Version 2.0</a>.
-
-
-
-[CONTRIBUTING.md]: https://github.com/camunda/camunda-bpm-platform/blob/master/CONTRIBUTING.md

--- a/core/src/main/java/org/camunda/connect/Connectors.java
+++ b/core/src/main/java/org/camunda/connect/Connectors.java
@@ -34,13 +34,17 @@ import org.camunda.connect.spi.ConnectorRequest;
  */
 public class Connectors {
 
-  protected static ConnectCoreLogger LOG = ConnectLogger.CORE_LOGGER;
+  protected static final ConnectCoreLogger LOG = ConnectLogger.CORE_LOGGER;
 
-  public static String HTTP_CONNECTOR_ID = "http-connector";
-  public static String SOAP_HTTP_CONNECTOR_ID = "soap-http-connector";
+  public static final String HTTP_CONNECTOR_ID = "http-connector";
+  public static final String SOAP_HTTP_CONNECTOR_ID = "soap-http-connector";
 
   /** The global instance of the manager */
-  static Connectors INSTANCE = new Connectors();
+  private static final Connectors INSTANCE = new Connectors();
+
+  private Connectors() {
+    /* hidden */
+  }
 
   /**
    * Provides the global instance of the Connectors manager.
@@ -54,27 +58,24 @@ public class Connectors {
    * @return the connector for the default http connector id or null if
    * no connector is registered for this id
    */
-  @SuppressWarnings("unchecked")
   public static <C extends Connector<? extends ConnectorRequest<?>>> C http() {
-    return (C) INSTANCE.getConnectorById(HTTP_CONNECTOR_ID);
+    return getConnector(HTTP_CONNECTOR_ID);
   }
 
   /**
    * @return the connector for the default soap http connector id or null
    * if no connector is registered for this id
    */
-  @SuppressWarnings("unchecked")
   public static <C extends Connector<? extends ConnectorRequest<?>>> C soap() {
-    return (C) INSTANCE.getConnectorById(SOAP_HTTP_CONNECTOR_ID);
+    return getConnector(SOAP_HTTP_CONNECTOR_ID);
   }
 
   /**
    * @return the connector for the given id or null if no connector is
    * registered for this id
    */
-  @SuppressWarnings("unchecked")
   public static <C extends Connector<? extends ConnectorRequest<?>>> C getConnector(String connectorId) {
-    return (C) INSTANCE.getConnectorById(connectorId);
+    return INSTANCE.getConnectorById(connectorId);
   }
 
   /**
@@ -126,7 +127,7 @@ public class Connectors {
    */
   public Set<Connector<? extends ConnectorRequest<?>>> getAllAvailableConnectors() {
     ensureConnectorProvidersInitialized();
-    return new HashSet<Connector<?>>(availableConnectors.values());
+    return new HashSet<>(availableConnectors.values());
   }
 
   /**
@@ -153,9 +154,9 @@ public class Connectors {
   }
 
   protected void initializeConnectors(ClassLoader classLoader) {
-    Map<String, Connector<?>> connectors = new HashMap<String, Connector<?>>();
+    Map<String, Connector<?>> connectors = new HashMap<>();
 
-    if(classLoader == null) {
+    if (classLoader == null) {
       classLoader = Connectors.class.getClassLoader();
     }
 
@@ -181,8 +182,7 @@ public class Connectors {
     String connectorId = provider.getConnectorId();
     if (connectors.containsKey(connectorId)) {
       throw LOG.multipleConnectorProvidersFound(connectorId);
-    }
-    else {
+    } else {
       Connector<?> connectorInstance = provider.createConnectorInstance();
       LOG.connectorProviderDiscovered(provider, connectorId, connectorInstance);
       connectors.put(connectorId, connectorInstance);

--- a/core/src/main/java/org/camunda/connect/impl/AbstractCloseableConnectorResponse.java
+++ b/core/src/main/java/org/camunda/connect/impl/AbstractCloseableConnectorResponse.java
@@ -30,7 +30,7 @@ import org.camunda.connect.spi.CloseableConnectorResponse;
  */
 public abstract class AbstractCloseableConnectorResponse extends AbstractConnectorResponse implements CloseableConnectorResponse {
 
-  private final static ConnectCoreLogger LOG = ConnectLogger.CORE_LOGGER;
+  private static final ConnectCoreLogger LOG = ConnectLogger.CORE_LOGGER;
 
   /**
    * Implements the default close behavior

--- a/core/src/main/java/org/camunda/connect/impl/AbstractConnector.java
+++ b/core/src/main/java/org/camunda/connect/impl/AbstractConnector.java
@@ -22,12 +22,11 @@ import java.util.List;
 
 import org.camunda.connect.spi.Connector;
 import org.camunda.connect.spi.ConnectorRequest;
-import org.camunda.connect.spi.ConnectorResponse;
 import org.camunda.connect.spi.ConnectorRequestInterceptor;
+import org.camunda.connect.spi.ConnectorResponse;
 
 /**
  * Abstract implementation of the connector interface.
- *
  * This implementation provides a linked list of interceptors and related methods for
  * handling interceptor invocation.
  *
@@ -41,9 +40,9 @@ public abstract class AbstractConnector<Q extends ConnectorRequest<R>, R extends
   /**
    * The {@link ConnectorRequestInterceptor} chain
    */
-  protected List<ConnectorRequestInterceptor> requestInterceptors = new LinkedList<ConnectorRequestInterceptor>();
+  protected List<ConnectorRequestInterceptor> requestInterceptors = new LinkedList<>();
 
-  public AbstractConnector(String connectorId) {
+  protected AbstractConnector(String connectorId) {
     this.connectorId = connectorId;
   }
 

--- a/core/src/main/java/org/camunda/connect/impl/AbstractConnectorRequest.java
+++ b/core/src/main/java/org/camunda/connect/impl/AbstractConnectorRequest.java
@@ -32,15 +32,15 @@ public abstract class AbstractConnectorRequest<R extends ConnectorResponse> impl
 
   protected Connector connector;
 
-  protected Map<String, Object> requestParameters = new HashMap<String, Object>();
+  protected Map<String, Object> requestParameters = new HashMap<>();
 
-  public AbstractConnectorRequest(Connector connector) {
+  protected AbstractConnectorRequest(Connector connector) {
     this.connector = connector;
   }
 
   @SuppressWarnings("unchecked")
   public R execute() {
-    if(!isRequestValid()) {
+    if (!isRequestValid()) {
       throw new RuntimeException("The request is invalid");
     }
     return (R) connector.execute(this);

--- a/core/src/main/java/org/camunda/connect/impl/AbstractConnectorResponse.java
+++ b/core/src/main/java/org/camunda/connect/impl/AbstractConnectorResponse.java
@@ -30,8 +30,8 @@ public abstract class AbstractConnectorResponse implements ConnectorResponse {
   protected Map<String, Object> responseParameters;
 
   public Map<String, Object> getResponseParameters() {
-    if(responseParameters == null) {
-      responseParameters = new HashMap<String, Object>();
+    if (responseParameters == null) {
+      responseParameters = new HashMap<>();
       collectResponseParameters(responseParameters);
     }
     return responseParameters;

--- a/core/src/main/java/org/camunda/connect/impl/AbstractRequestInvocation.java
+++ b/core/src/main/java/org/camunda/connect/impl/AbstractRequestInvocation.java
@@ -18,8 +18,8 @@ package org.camunda.connect.impl;
 
 import java.util.List;
 
-import org.camunda.connect.spi.ConnectorRequest;
 import org.camunda.connect.spi.ConnectorInvocation;
+import org.camunda.connect.spi.ConnectorRequest;
 import org.camunda.connect.spi.ConnectorRequestInterceptor;
 
 /**
@@ -40,7 +40,7 @@ public abstract class AbstractRequestInvocation<T> implements ConnectorInvocatio
 
   protected ConnectorRequest<?> request;
 
-  public AbstractRequestInvocation(T target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain) {
+  protected AbstractRequestInvocation(T target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain) {
     this.target = target;
     this.request = request;
     this.interceptorChain = interceptorChain;
@@ -57,7 +57,7 @@ public abstract class AbstractRequestInvocation<T> implements ConnectorInvocatio
 
   public Object proceed() throws Exception {
     currentIndex++;
-    if(interceptorChain.size() > currentIndex) {
+    if (interceptorChain.size() > currentIndex) {
       return interceptorChain.get(currentIndex).handleInvocation(this);
 
     } else {

--- a/core/src/main/java/org/camunda/connect/impl/ConnectLogger.java
+++ b/core/src/main/java/org/camunda/connect/impl/ConnectLogger.java
@@ -22,6 +22,6 @@ public abstract class ConnectLogger extends BaseLogger {
 
   public static final String PROJECT_CODE = "CNCT";
 
-  public static ConnectCoreLogger CORE_LOGGER = createLogger(ConnectCoreLogger.class, PROJECT_CODE, "org.camunda.bpm.connect", "01");
+  public static final ConnectCoreLogger CORE_LOGGER = createLogger(ConnectCoreLogger.class, PROJECT_CODE, "org.camunda.bpm.connect", "01");
 
 }

--- a/core/src/main/java/org/camunda/connect/impl/DebugRequestInterceptor.java
+++ b/core/src/main/java/org/camunda/connect/impl/DebugRequestInterceptor.java
@@ -17,8 +17,8 @@
 package org.camunda.connect.impl;
 
 import org.camunda.connect.spi.ConnectorInvocation;
-import org.camunda.connect.spi.ConnectorRequestInterceptor;
 import org.camunda.connect.spi.ConnectorRequest;
+import org.camunda.connect.spi.ConnectorRequestInterceptor;
 
 /**
  * <p>
@@ -60,8 +60,7 @@ public class DebugRequestInterceptor implements ConnectorRequestInterceptor {
     target = invocation.getTarget();
     if (proceed) {
       return invocation.proceed();
-    }
-    else {
+    } else {
       return response;
     }
   }

--- a/core/src/main/java/org/camunda/connect/spi/CloseableConnectorResponse.java
+++ b/core/src/main/java/org/camunda/connect/spi/CloseableConnectorResponse.java
@@ -27,6 +27,6 @@ package org.camunda.connect.spi;
  */
 public interface CloseableConnectorResponse extends ConnectorResponse {
 
-  public void close();
+  void close();
 
 }

--- a/core/src/main/java/org/camunda/connect/spi/Connector.java
+++ b/core/src/main/java/org/camunda/connect/spi/Connector.java
@@ -87,4 +87,5 @@ public interface Connector<Q extends ConnectorRequest<?>> {
    * @return the result.
    */
   ConnectorResponse execute(Q request);
+
 }

--- a/core/src/main/java/org/camunda/connect/spi/ConnectorInvocation.java
+++ b/core/src/main/java/org/camunda/connect/spi/ConnectorInvocation.java
@@ -30,7 +30,7 @@ public interface ConnectorInvocation {
    * The underlying raw request.
    * @return the raw request as executed by the connector
    */
-  public Object getTarget();
+  Object getTarget();
 
   /**
    * <p>The connector request as created through the API. Accessing the request from an
@@ -42,7 +42,7 @@ public interface ConnectorInvocation {
    *
    * @return the connector request
    */
-  public ConnectorRequest<?> getRequest();
+  ConnectorRequest<?> getRequest();
 
   /**
    * Makes the request proceed through the interceptor chain.
@@ -52,6 +52,6 @@ public interface ConnectorInvocation {
    * @return the result of the invocation.
    * @throws Exception
    */
-  public Object proceed() throws Exception;
+  Object proceed() throws Exception;
 
 }

--- a/core/src/test/java/org/camunda/connect/spi/ConnectorsTest.java
+++ b/core/src/test/java/org/camunda/connect/spi/ConnectorsTest.java
@@ -18,8 +18,6 @@ package org.camunda.connect.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Set;
-
 import org.camunda.connect.Connectors;
 import org.camunda.connect.dummy.DummyConnector;
 import org.junit.Test;

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -19,15 +19,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-    <!-- commons-codec is a transitive dependency of httpclient;
-      we override its version here in order to update the default commons-codec
-      version which has known vulnerabilities, see https://jira.camunda.com/browse/CAM-12774 -->
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
     </dependency>
 
     <dependency>

--- a/http-client/src/main/java/org/camunda/connect/httpclient/HttpConnector.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/HttpConnector.java
@@ -21,6 +21,6 @@ import org.camunda.connect.spi.Connector;
 
 public interface HttpConnector extends Connector<HttpRequest> {
 
-  static final String ID = Connectors.HTTP_CONNECTOR_ID;
+  String ID = Connectors.HTTP_CONNECTOR_ID;
 
 }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/HttpResponse.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/HttpResponse.java
@@ -22,9 +22,9 @@ import org.camunda.connect.spi.CloseableConnectorResponse;
 
 public interface HttpResponse extends CloseableConnectorResponse {
 
-  static final String PARAM_NAME_STATUS_CODE = "statusCode";
-  static final String PARAM_NAME_RESPONSE = "response";
-  static final String PARAM_NAME_RESPONSE_HEADERS = "headers";
+  String PARAM_NAME_STATUS_CODE = "statusCode";
+  String PARAM_NAME_RESPONSE = "response";
+  String PARAM_NAME_RESPONSE_HEADERS = "headers";
 
   /**
    * @return the HTTP status code of the response

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpConnector.java
@@ -18,24 +18,26 @@ package org.camunda.connect.httpclient.impl;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.config.RequestConfig.Builder;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.config.RequestConfig.Builder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.camunda.connect.httpclient.HttpBaseRequest;
 import org.camunda.connect.httpclient.HttpResponse;
 import org.camunda.connect.httpclient.impl.util.ParseUtil;
@@ -43,15 +45,15 @@ import org.camunda.connect.impl.AbstractConnector;
 
 public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R extends HttpResponse> extends AbstractConnector<Q, R> {
 
-  protected static HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  protected static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
   protected CloseableHttpClient httpClient;
   protected final Charset charset;
 
-  public AbstractHttpConnector(String connectorId) {
+  protected AbstractHttpConnector(String connectorId) {
     super(connectorId);
     httpClient = createClient();
-    charset = Charset.forName("utf-8");
+    charset = StandardCharsets.UTF_8;
   }
 
   protected CloseableHttpClient createClient() {
@@ -68,30 +70,26 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
 
   @Override
   public R execute(Q request) {
-    HttpRequestBase httpRequest = createHttpRequest(request);
+    BasicClassicHttpRequest httpRequest = createHttpRequest(request);
 
     HttpRequestInvocation invocation = new HttpRequestInvocation(httpRequest, request, requestInterceptors, httpClient);
 
     try {
-      return createResponse((CloseableHttpResponse) invocation.proceed());
+      return createResponse((ClassicHttpResponse) invocation.proceed());
     } catch (Exception e) {
       throw LOG.unableToExecuteRequest(e);
     }
-
   }
 
-  protected abstract R createResponse(CloseableHttpResponse response);
-
-  @Override
-  public abstract Q createRequest();
+  protected abstract R createResponse(ClassicHttpResponse response);
 
   /**
-   * creates a apache Http* representation of the request.
+   * creates a apache Http representation of the request.
    *
    * @param request the given request
-   * @return {@link HttpRequestBase} an apache representation of the request
+   * @return {@link BasicClassicHttpRequest} an apache representation of the request
    */
-  protected <T extends HttpRequestBase> T createHttpRequest(Q request) {
+  protected <T extends BasicClassicHttpRequest> T createHttpRequest(Q request) {
     T httpRequest = createHttpRequestBase(request);
 
     applyConfig(httpRequest, request.getConfigOptions());
@@ -104,7 +102,7 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
   }
 
   @SuppressWarnings("unchecked")
-  protected <T extends HttpRequestBase> T createHttpRequestBase(Q request) {
+  protected <T extends BasicClassicHttpRequest> T createHttpRequestBase(Q request) {
     String url = request.getUrl();
     if (url != null && !url.trim().isEmpty()) {
       String method = request.getMethod();
@@ -127,13 +125,12 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
       } else {
         throw LOG.unknownHttpMethod(method);
       }
-    }
-    else {
+    } else {
       throw LOG.requestUrlRequired();
     }
   }
 
-  protected <T extends HttpRequestBase> void applyHeaders(T httpRequest, Map<String, String> headers) {
+  protected <T extends BasicClassicHttpRequest> void applyHeaders(T httpRequest, Map<String, String> headers) {
     if (headers != null) {
       for (Map.Entry<String, String> entry : headers.entrySet()) {
         httpRequest.setHeader(entry.getKey(), entry.getValue());
@@ -142,31 +139,32 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     }
   }
 
-  protected <T extends HttpRequestBase> void applyPayload(T httpRequest, Q request) {
+  protected <T extends BasicClassicHttpRequest> void applyPayload(T httpRequest, Q request) {
     if (httpMethodSupportsPayload(httpRequest)) {
       if (request.getPayload() != null) {
         byte[] bytes = request.getPayload().getBytes(charset);
         ByteArrayInputStream payload = new ByteArrayInputStream(bytes);
-        InputStreamEntity entity = new InputStreamEntity(payload, bytes.length);
-        ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(entity);
+        InputStreamEntity entity = new InputStreamEntity(payload, bytes.length, ContentType.parse(request.getContentType()));
+        httpRequest.setEntity(entity);
       }
-    }
-    else if (request.getPayload() != null) {
+    } else if (request.getPayload() != null) {
       LOG.payloadIgnoredForHttpMethod(request.getMethod());
     }
   }
 
-  protected <T extends HttpRequestBase> boolean httpMethodSupportsPayload(T httpRequest) {
-    return httpRequest instanceof HttpEntityEnclosingRequestBase;
+  protected <T extends BasicClassicHttpRequest> boolean httpMethodSupportsPayload(T httpRequest) {
+    return httpRequest instanceof HttpUriRequestBase;
   }
 
-  protected <T extends HttpRequestBase> void applyConfig(T httpRequest, Map<String, Object> configOptions) {
-    Builder configBuilder = RequestConfig.custom();
-    if (configOptions != null && !configOptions.isEmpty()) {
-      ParseUtil.parseConfigOptions(configOptions, configBuilder);
+  protected <T extends BasicClassicHttpRequest> void applyConfig(T httpRequest, Map<String, Object> configOptions) {
+    if (httpMethodSupportsPayload(httpRequest)) {
+      Builder configBuilder = RequestConfig.custom();
+      if (configOptions != null && !configOptions.isEmpty()) {
+        ParseUtil.parseConfigOptions(configOptions, configBuilder);
+      }
+      RequestConfig requestConfig = configBuilder.build();
+      ((HttpUriRequestBase) httpRequest).setConfig(requestConfig);
     }
-    RequestConfig requestConfig = configBuilder.build();
-    httpRequest.setConfig(requestConfig);
   }
 
 

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/AbstractHttpRequest.java
@@ -19,14 +19,14 @@ package org.camunda.connect.httpclient.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
 import org.camunda.connect.httpclient.HttpBaseRequest;
 import org.camunda.connect.httpclient.HttpResponse;
 import org.camunda.connect.impl.AbstractConnectorRequest;
@@ -34,7 +34,7 @@ import org.camunda.connect.spi.Connector;
 
 public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends HttpResponse> extends AbstractConnectorRequest<R> {
 
-  private final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
   public AbstractHttpRequest(Connector connector) {
     super(connector);
@@ -64,12 +64,11 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
   public Q header(String field, String value) {
     if (field == null || field.isEmpty() || value == null || value.isEmpty()) {
       LOG.ignoreHeader(field, value);
-    }
-    else {
+    } else {
       Map<String, String> headers = getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_HEADERS);
 
       if (headers == null) {
-        headers = new HashMap<String, String>();
+        headers = new HashMap<>();
         setRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_HEADERS, headers);
       }
       headers.put(field, value);
@@ -82,8 +81,7 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
     Map<String, String> headers = getHeaders();
     if (headers != null) {
       return headers.get(field);
-    }
-    else {
+    } else {
       return null;
     }
   }
@@ -163,7 +161,7 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
       Map<String, Object> config = getConfigOptions();
 
       if (config == null) {
-        config = new HashMap<String, Object>();
+        config = new HashMap<>();
         setRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_CONFIG, config);
       }
       config.put(field, value);

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorImpl.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorImpl.java
@@ -16,7 +16,7 @@
  */
 package org.camunda.connect.httpclient.impl;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.camunda.connect.httpclient.HttpConnector;
 import org.camunda.connect.httpclient.HttpRequest;
 import org.camunda.connect.httpclient.HttpResponse;
@@ -35,7 +35,7 @@ public class HttpConnectorImpl extends AbstractHttpConnector<HttpRequest, HttpRe
     return new HttpRequestImpl(this);
   }
 
-  protected HttpResponse createResponse(CloseableHttpResponse response) {
+  protected HttpResponse createResponse(ClassicHttpResponse response) {
     return new HttpResponseImpl(response);
   }
 

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpConnectorLogger.java
@@ -28,7 +28,6 @@ public class HttpConnectorLogger extends ConnectLogger {
 
   public void ignoreHeader(String field, String value) {
     logInfo("002", "Ignoring header with name '{}' and value '{}'", field, value);
-
   }
 
   public void payloadIgnoredForHttpMethod(String method) {

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpLogger.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpLogger.java
@@ -22,5 +22,5 @@ public abstract class HttpLogger extends BaseLogger {
 
   public static final String PROJECT_CODE = "HTCL";
 
-  public static HttpConnectorLogger HTTP_LOGGER = createLogger(HttpConnectorLogger.class, PROJECT_CODE, "org.camunda.bpm.connect.httpclient.connector", "02");
+  public static final HttpConnectorLogger HTTP_LOGGER = createLogger(HttpConnectorLogger.class, PROJECT_CODE, "org.camunda.bpm.connect.httpclient.connector", "02");
 }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpRequestInvocation.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpRequestInvocation.java
@@ -18,17 +18,17 @@ package org.camunda.connect.httpclient.impl;
 
 import java.util.List;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.camunda.connect.spi.ConnectorRequest;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.camunda.connect.impl.AbstractRequestInvocation;
+import org.camunda.connect.spi.ConnectorRequest;
 import org.camunda.connect.spi.ConnectorRequestInterceptor;
 
-public class HttpRequestInvocation  extends AbstractRequestInvocation<HttpRequestBase> {
+public class HttpRequestInvocation extends AbstractRequestInvocation<BasicClassicHttpRequest> {
 
   protected HttpClient client;
 
-  public HttpRequestInvocation(HttpRequestBase target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain, HttpClient client) {
+  public HttpRequestInvocation(BasicClassicHttpRequest target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain, HttpClient client) {
     super(target, request, interceptorChain);
     this.client = client;
   }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpResponseImpl.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/HttpResponseImpl.java
@@ -21,19 +21,19 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.camunda.commons.utils.IoUtil;
 import org.camunda.connect.httpclient.HttpResponse;
 import org.camunda.connect.impl.AbstractCloseableConnectorResponse;
-import org.camunda.commons.utils.IoUtil;
 
 public class HttpResponseImpl extends AbstractCloseableConnectorResponse implements HttpResponse {
 
-  private final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
-  protected CloseableHttpResponse httpResponse;
+  protected ClassicHttpResponse httpResponse;
 
-  public HttpResponseImpl(CloseableHttpResponse httpResponse) {
+  public HttpResponseImpl(ClassicHttpResponse httpResponse) {
     this.httpResponse = httpResponse;
   }
 
@@ -53,16 +53,13 @@ public class HttpResponseImpl extends AbstractCloseableConnectorResponse impleme
     Map<String, String> headers = getHeaders();
     if (headers != null) {
       return headers.get(field);
-    }
-    else {
+    } else {
       return null;
     }
   }
 
   protected void collectResponseParameters(Map<String, Object> responseParameters) {
-    if (httpResponse.getStatusLine() != null) {
-      responseParameters.put(PARAM_NAME_STATUS_CODE, httpResponse.getStatusLine().getStatusCode());
-    }
+    responseParameters.put(PARAM_NAME_STATUS_CODE, httpResponse.getCode());
     collectResponseHeaders();
 
     if (httpResponse.getEntity() != null) {
@@ -78,8 +75,8 @@ public class HttpResponseImpl extends AbstractCloseableConnectorResponse impleme
   }
 
   protected void collectResponseHeaders() {
-    Map<String, String> headers = new HashMap<String, String>();
-    for (Header header : httpResponse.getAllHeaders()) {
+    Map<String, String> headers = new HashMap<>();
+    for (Header header : httpResponse.getHeaders()) {
       headers.put(header.getName(), header.getValue());
     }
     responseParameters.put(PARAM_NAME_RESPONSE_HEADERS, headers);

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/RequestConfigOption.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/RequestConfigOption.java
@@ -16,12 +16,12 @@
  */
 package org.camunda.connect.httpclient.impl;
 
-import java.net.InetAddress;
 import java.util.Collection;
 import java.util.function.BiConsumer;
 
-import org.apache.http.HttpHost;
-import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.hc.client5.http.config.RequestConfig.Builder;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.Timeout;
 
 public enum RequestConfigOption {
 
@@ -29,43 +29,37 @@ public enum RequestConfigOption {
       (builder, value) -> builder.setAuthenticationEnabled((boolean) value)),
   CIRCULAR_REDIRECTS_ALLOWED("circular-redirects-allowed",
       (builder, value) -> builder.setCircularRedirectsAllowed((boolean) value)),
-  CONNECTION_TIMEOUT("connection-timeout",
-      (builder, value) -> builder.setConnectTimeout((int) value)),
+  CONNECT_TIMEOUT("connect-timeout",
+      (builder, value) -> builder.setConnectTimeout((Timeout) value)),
+  CONNECTION_KEEP_ALIVE("connection-keep-alive",
+      (builder, value) -> builder.setConnectionKeepAlive((Timeout) value)),
   CONNECTION_REQUEST_TIMEOUT("connection-request-timeout",
-      (builder, value) -> builder.setConnectionRequestTimeout((int) value)),
+      (builder, value) -> builder.setConnectionRequestTimeout((Timeout) value)),
   CONTENT_COMPRESSION_ENABLED("content-compression-enabled",
       (builder, value) -> builder.setContentCompressionEnabled((boolean) value)),
   COOKIE_SPEC("cookie-spec",
       (builder, value) -> builder.setCookieSpec((String) value)),
-  DECOMPRESSION_ENABLED("decompression-enabled",
-      (builder, value) -> builder.setDecompressionEnabled((boolean) value)),
   EXPECT_CONTINUE_ENABLED("expect-continue-enabled",
       (builder, value) -> builder.setExpectContinueEnabled((boolean) value)),
-  LOCAL_ADDRESS("local-address",
-      (builder, value) -> builder.setLocalAddress((InetAddress) value)),
+  HARD_CANCELLATION_ENABLED("hard-cancellation-enabled",
+      (builder, value) -> builder.setHardCancellationEnabled((boolean) value)),
   MAX_REDIRECTS("max-redirects",
       (builder, value) -> builder.setMaxRedirects((int) value)),
-  NORMALIZE_URI("normalize-uri",
-      (builder, value) -> builder.setNormalizeUri((boolean) value)),
   PROXY("proxy",
       (builder, value) -> builder.setProxy((HttpHost) value)),
   PROXY_PREFERRED_AUTH_SCHEMES("proxy-preferred-auth-scheme",
       (builder, value) -> builder.setProxyPreferredAuthSchemes((Collection<String>) value)),
-  REDIRECTS_ENABLED("relative-redirects-allowed",
+  REDIRECTS_ENABLED("redirects-enabled",
       (builder, value) -> builder.setRedirectsEnabled((boolean) value)),
-  RELATIVE_REDIRECTS_ALLOWED("relative-redirects-allowed",
-      (builder, value) -> builder.setRelativeRedirectsAllowed((boolean) value)),
-  SOCKET_TIMEOUT("socket-timeout",
-      (builder, value) -> builder.setSocketTimeout((int) value)),
-  STALE_CONNECTION_CHECK_ENABLED("stale-connection-check-enabled",
-      (builder, value) -> builder.setStaleConnectionCheckEnabled((boolean) value)),
+  RESPONSE_TIMEOUT("response-timeout",
+      (builder, value) -> builder.setResponseTimeout((Timeout) value)),
   TARGET_PREFERRED_AUTH_SCHEMES("target-preferred-auth-schemes",
       (builder, value) -> builder.setTargetPreferredAuthSchemes((Collection<String>) value));
 
-  private String name;
-  private BiConsumer<Builder, Object> consumer;
+  private final String name;
+  private final BiConsumer<Builder, Object> consumer;
 
-  private RequestConfigOption(String name, BiConsumer<Builder, Object> consumer) {
+  RequestConfigOption(String name, BiConsumer<Builder, Object> consumer) {
     this.name = name;
     this.consumer = consumer;
   }

--- a/http-client/src/main/java/org/camunda/connect/httpclient/impl/util/ParseUtil.java
+++ b/http-client/src/main/java/org/camunda/connect/httpclient/impl/util/ParseUtil.java
@@ -18,14 +18,18 @@ package org.camunda.connect.httpclient.impl.util;
 
 import java.util.Map;
 
-import org.apache.http.client.config.RequestConfig.Builder;
-import org.camunda.connect.httpclient.impl.RequestConfigOption;
-import org.camunda.connect.httpclient.impl.HttpConnectorLogger;
+import org.apache.hc.client5.http.config.RequestConfig.Builder;
 import org.camunda.connect.httpclient.impl.HttpLogger;
+import org.camunda.connect.httpclient.impl.HttpConnectorLogger;
+import org.camunda.connect.httpclient.impl.RequestConfigOption;
 
-public class ParseUtil {
+public final class ParseUtil {
 
-  protected static HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+
+  private ParseUtil() {
+    /* hidden */
+  }
 
   public static void parseConfigOptions(Map<String, Object> configOptions, Builder configBuilder) {
     for (RequestConfigOption option : RequestConfigOption.values()) {

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorSystemPropertiesTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorSystemPropertiesTest.java
@@ -16,20 +16,24 @@
  */
 package org.camunda.connect.httpclient;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.http.protocol.HTTP;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.camunda.connect.httpclient.impl.HttpConnectorImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * Since Apache HTTP client makes it extremely hard to test the proper configuration
@@ -50,7 +54,7 @@ public class HttpConnectorSystemPropertiesTest {
 
   @Before
   public void setUp() {
-    updatedSystemProperties = new HashSet<String>();
+    updatedSystemProperties = new HashSet<>();
     wireMockRule.stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
   }
 
@@ -65,8 +69,7 @@ public class HttpConnectorSystemPropertiesTest {
     if (!System.getProperties().containsKey(property)) {
       updatedSystemProperties.add(property);
       System.setProperty(property, value);
-    }
-    else {
+    } else {
       throw new RuntimeException("Cannot perform test: System property "
           + property + " is already set. Will not attempt to overwrite this property.");
     }
@@ -83,7 +86,7 @@ public class HttpConnectorSystemPropertiesTest {
     customConnector.createRequest().url("http://localhost:" + PORT).get().execute();
 
     // then
-    verify(getRequestedFor(urlEqualTo("/")).withHeader(HTTP.USER_AGENT, equalTo("foo")));
+    verify(getRequestedFor(urlEqualTo("/")).withHeader(HttpHeaders.USER_AGENT, equalTo("foo")));
 
   }
 }

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpConnectorTest.java
@@ -21,16 +21,16 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.camunda.commons.utils.IoUtil;
 import org.camunda.connect.ConnectorRequestException;
 import org.camunda.connect.Connectors;
@@ -133,10 +133,10 @@ public class HttpConnectorTest {
   }
 
   @Test
-  public void shouldSetUrlOnHttpRequest() {
+  public void shouldSetUrlOnHttpRequest() throws Exception {
     connector.createRequest().url(EXAMPLE_URL).get().execute();
     HttpGet request = interceptor.getTarget();
-    assertThat(request.getURI().toASCIIString()).isEqualTo(EXAMPLE_URL);
+    assertThat(request.getUri().toASCIIString()).isEqualTo(EXAMPLE_URL);
   }
 
   @Test
@@ -153,7 +153,7 @@ public class HttpConnectorTest {
   public void shouldSetHeadersOnHttpRequest() {
     connector.createRequest().url(EXAMPLE_URL).header("foo", "bar").header("hello", "world").get().execute();
     HttpGet request = interceptor.getTarget();
-    Header[] headers = request.getAllHeaders();
+    Header[] headers = request.getHeaders();
     assertThat(headers).hasSize(2);
   }
 
@@ -174,12 +174,12 @@ public class HttpConnectorTest {
     assertThat(contentLength).isEqualTo(EXAMPLE_PAYLOAD.length());
   }
 
-  protected void verifyHttpRequest(Class<? extends HttpRequestBase> requestClass) {
+  protected void verifyHttpRequest(Class<? extends BasicClassicHttpRequest> requestClass) {
     Object target = interceptor.getTarget();
     assertThat(target).isInstanceOf(requestClass);
 
     HttpRequest request = interceptor.getRequest();
-    HttpRequestBase requestBase = (HttpRequestBase) target;
+    BasicClassicHttpRequest requestBase = (BasicClassicHttpRequest) target;
     assertThat(requestBase.getMethod()).isEqualTo(request.getMethod());
   }
 

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpRequestTest.java
@@ -21,14 +21,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
 import org.camunda.connect.Connectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -148,7 +148,7 @@ public class HttpRequestTest {
 
     request.setRequestParameter("hello", "world");
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("foo", "bar");
     params.put("number", 42);
     request.setRequestParameters(params);
@@ -166,13 +166,13 @@ public class HttpRequestTest {
     HttpRequest request = connector.createRequest()
         .configOption("object-field", value)
         .configOption("int-field", 15)
-        .configOption("long-field", 15l)
+        .configOption("long-field", 15L)
         .configOption("boolean-field", true)
         .configOption("string-field", "string-value");
 
     assertThat(request.getConfigOption("object-field")).isEqualTo(value);
     assertThat(request.getConfigOption("int-field")).isEqualTo(15);
-    assertThat(request.getConfigOption("long-field")).isEqualTo(15l);
+    assertThat(request.getConfigOption("long-field")).isEqualTo(15L);
     assertThat(request.getConfigOption("boolean-field")).isEqualTo(true);
     assertThat(request.getConfigOption("string-field")).isEqualTo("string-value");
   }

--- a/http-client/src/test/java/org/camunda/connect/httpclient/HttpResponseTest.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/HttpResponseTest.java
@@ -37,7 +37,7 @@ public class HttpResponseTest {
 
   @Test
   public void testResponseCode() {
-    testResponse.statusCode(123);
+    testResponse.code(123);
     HttpResponse response = getResponse();
     assertThat(response.getStatusCode()).isEqualTo(123);
   }

--- a/http-client/src/test/java/org/camunda/connect/httpclient/TestResponse.java
+++ b/http-client/src/test/java/org/camunda/connect/httpclient/TestResponse.java
@@ -16,27 +16,28 @@
  */
 package org.camunda.connect.httpclient;
 
-import java.io.IOException;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
 
-import org.apache.http.HttpVersion;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHttpResponse;
 
-public class TestResponse extends BasicHttpResponse implements CloseableHttpResponse {
+
+public class TestResponse extends BasicHttpResponse implements ClassicHttpResponse {
+
+  private HttpEntity entity;
 
   public TestResponse() {
-    this(HttpVersion.HTTP_1_1, 200, "OK");
+    this(200, "OK");
   }
 
-  public TestResponse(ProtocolVersion ver, int code, String reason) {
-    super(ver, code, reason);
+  public TestResponse(int code, String reason) {
+    super(code, reason);
   }
 
-  public TestResponse statusCode(int statusCode) {
-    setStatusCode(statusCode);
+  public TestResponse code(int code) {
+    setCode(code);
     return this;
   }
 
@@ -52,15 +53,24 @@ public class TestResponse extends BasicHttpResponse implements CloseableHttpResp
   public TestResponse payload(String payload, ContentType contentType) {
     if (payload != null) {
       setEntity(new StringEntity(payload, contentType));
-    }
-    else {
+    } else {
       setEntity(null);
     }
     return this;
   }
 
-  public void close() throws IOException {
-
+  @Override
+  public HttpEntity getEntity() {
+    return entity;
   }
 
+  @Override
+  public void setEntity(HttpEntity entity) {
+    this.entity = entity;
+  }
+
+  @Override
+  public void close() {
+    /* NOP */
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,8 @@
   <properties>
     <assertj.version>2.9.1</assertj.version>
     <commons.version>1.13.0</commons.version>
-    <commons-codec.version>1.15</commons-codec.version>
     <connect.version.old>1.6.0</connect.version.old>
-    <httpclient.version>4.5.13</httpclient.version>
+    <httpclient.version>5.3.1</httpclient.version>
     <junit.version>4.13.1</junit.version>
     <logback.version>1.2.11</logback.version>
     <mockito.version>1.9.5</mockito.version>
@@ -49,15 +48,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
         <version>${httpclient.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
       </dependency>
 
       <dependency>

--- a/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/SoapHttpConnector.java
+++ b/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/SoapHttpConnector.java
@@ -21,6 +21,6 @@ import org.camunda.connect.spi.Connector;
 
 public interface SoapHttpConnector extends Connector<SoapHttpRequest> {
 
-  static final String ID = Connectors.SOAP_HTTP_CONNECTOR_ID;
+  String ID = Connectors.SOAP_HTTP_CONNECTOR_ID;
 
 }

--- a/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpConnectorImpl.java
+++ b/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpConnectorImpl.java
@@ -16,8 +16,8 @@
  */
 package org.camunda.connect.httpclient.soap.impl;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.camunda.connect.httpclient.impl.AbstractHttpConnector;
 import org.camunda.connect.httpclient.impl.AbstractHttpRequest;
 import org.camunda.connect.httpclient.soap.SoapHttpConnector;
@@ -26,7 +26,7 @@ import org.camunda.connect.httpclient.soap.SoapHttpResponse;
 
 public class SoapHttpConnectorImpl extends AbstractHttpConnector<SoapHttpRequest, SoapHttpResponse> implements SoapHttpConnector {
 
-  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_CONNECTOR_LOGGER;
+  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_HTTP_CONNECTOR_LOGGER;
 
   public SoapHttpConnectorImpl() {
     super(SoapHttpConnector.ID);
@@ -40,20 +40,20 @@ public class SoapHttpConnectorImpl extends AbstractHttpConnector<SoapHttpRequest
     return new SoapHttpRequestImpl(this);
   }
 
-  protected SoapHttpResponse createResponse(CloseableHttpResponse response) {
+  protected SoapHttpResponse createResponse(ClassicHttpResponse response) {
     return new SoapHttpResponseImpl(response);
   }
 
   @Override
   public SoapHttpResponse execute(SoapHttpRequest request) {
     // always use the POST method
-    ((AbstractHttpRequest) request).post();
+    ((AbstractHttpRequest<?, ?>) request).post();
 
     return super.execute(request);
   }
 
   @Override
-  protected <T extends HttpRequestBase> void applyPayload(T httpRequest, SoapHttpRequest request) {
+  protected <T extends BasicClassicHttpRequest> void applyPayload(T httpRequest, SoapHttpRequest request) {
     // SOAP requires soap envelop body
     if (request.getPayload() == null || request.getPayload().trim().isEmpty()) {
       throw LOG.noPayloadSet();

--- a/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpConnectorProviderImpl.java
+++ b/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpConnectorProviderImpl.java
@@ -17,9 +17,9 @@
 package org.camunda.connect.httpclient.soap.impl;
 
 import org.camunda.connect.httpclient.soap.SoapHttpConnector;
-import org.camunda.connect.spi.ConnectorProvider;
+import org.camunda.connect.httpclient.soap.SoapHttpConnectorProvider;
 
-public class SoapHttpConnectorProviderImpl implements ConnectorProvider {
+public class SoapHttpConnectorProviderImpl implements SoapHttpConnectorProvider {
 
   public String getConnectorId() {
     return SoapHttpConnector.ID;

--- a/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpLogger.java
+++ b/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpLogger.java
@@ -22,6 +22,6 @@ public abstract class SoapHttpLogger extends BaseLogger {
 
   public static final String PROJECT_CODE = "SOAPC";
 
-  public static SoapHttpConnectorLogger SOAP_CONNECTOR_LOGGER = createLogger(SoapHttpConnectorLogger.class, PROJECT_CODE, "org.camunda.bpm.connect.soap.httpclient.connector", "01");
+  public static final SoapHttpConnectorLogger SOAP_HTTP_CONNECTOR_LOGGER = createLogger(SoapHttpConnectorLogger.class, PROJECT_CODE, "org.camunda.bpm.connect.soap.httpclient.connector", "01");
 
 }

--- a/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpRequestImpl.java
+++ b/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpRequestImpl.java
@@ -16,7 +16,8 @@
  */
 package org.camunda.connect.httpclient.soap.impl;
 
-import org.apache.http.client.methods.HttpPost;
+
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.camunda.connect.httpclient.impl.AbstractHttpRequest;
 import org.camunda.connect.httpclient.soap.SoapHttpConnector;
 import org.camunda.connect.httpclient.soap.SoapHttpRequest;
@@ -24,7 +25,7 @@ import org.camunda.connect.httpclient.soap.SoapHttpResponse;
 
 public class SoapHttpRequestImpl extends AbstractHttpRequest<SoapHttpRequest, SoapHttpResponse> implements SoapHttpRequest {
 
-  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_CONNECTOR_LOGGER;
+  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_HTTP_CONNECTOR_LOGGER;
 
   public SoapHttpRequestImpl(SoapHttpConnector connector) {
     super(connector);

--- a/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpResponseImpl.java
+++ b/soap-http-client/src/main/java/org/camunda/connect/httpclient/soap/impl/SoapHttpResponseImpl.java
@@ -16,13 +16,13 @@
  */
 package org.camunda.connect.httpclient.soap.impl;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.camunda.connect.httpclient.impl.HttpResponseImpl;
 import org.camunda.connect.httpclient.soap.SoapHttpResponse;
 
 public class SoapHttpResponseImpl extends HttpResponseImpl implements SoapHttpResponse {
 
-  public SoapHttpResponseImpl(CloseableHttpResponse httpResponse) {
+  public SoapHttpResponseImpl(ClassicHttpResponse httpResponse) {
     super(httpResponse);
   }
 

--- a/soap-http-client/src/test/java/org/camunda/connect/httpclient/soap/SoapHttpConnectorSystemPropertiesTest.java
+++ b/soap-http-client/src/test/java/org/camunda/connect/httpclient/soap/SoapHttpConnectorSystemPropertiesTest.java
@@ -14,31 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.connect.soap.httpclient;
+package org.camunda.connect.httpclient.soap;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.http.protocol.HTTP;
-import org.camunda.connect.httpclient.HttpConnector;
-import org.camunda.connect.httpclient.impl.HttpConnectorImpl;
-import org.camunda.connect.httpclient.soap.SoapHttpConnector;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.camunda.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * Since Apache HTTP client makes it extremely hard to test the proper configuration
@@ -59,7 +54,7 @@ public class SoapHttpConnectorSystemPropertiesTest {
 
   @Before
   public void setUp() {
-    updatedSystemProperties = new HashSet<String>();
+    updatedSystemProperties = new HashSet<>();
     wireMockRule.stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
   }
 
@@ -74,8 +69,7 @@ public class SoapHttpConnectorSystemPropertiesTest {
     if (!System.getProperties().containsKey(property)) {
       updatedSystemProperties.add(property);
       System.setProperty(property, value);
-    }
-    else {
+    } else {
       throw new RuntimeException("Cannot perform test: System property "
           + property + " is already set. Will not attempt to overwrite this property.");
     }
@@ -92,7 +86,7 @@ public class SoapHttpConnectorSystemPropertiesTest {
     customConnector.createRequest().url("http://localhost:" + PORT).payload("test").execute();
 
     // then
-    verify(postRequestedFor(urlEqualTo("/")).withHeader(HTTP.USER_AGENT, equalTo("foo")));
+    verify(postRequestedFor(urlEqualTo("/")).withHeader(HttpHeaders.USER_AGENT, equalTo("foo")));
 
   }
 }

--- a/soap-http-client/src/test/java/org/camunda/connect/httpclient/soap/SoapHttpConnectorTest.java
+++ b/soap-http-client/src/test/java/org/camunda/connect/httpclient/soap/SoapHttpConnectorTest.java
@@ -14,13 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.connect.soap.httpclient;
+package org.camunda.connect.httpclient.soap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.http.client.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.camunda.connect.Connectors;
-import org.camunda.connect.httpclient.soap.SoapHttpConnector;
 import org.camunda.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 import org.camunda.connect.impl.DebugRequestInterceptor;
 import org.camunda.connect.spi.Connector;

--- a/soap-http-client/src/test/java/org/camunda/connect/httpclient/soap/SoapHttpRequestTest.java
+++ b/soap-http-client/src/test/java/org/camunda/connect/httpclient/soap/SoapHttpRequestTest.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.connect.soap.httpclient;
+package org.camunda.connect.httpclient.soap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.camunda.connect.Connectors;
-import org.camunda.connect.httpclient.soap.SoapHttpConnector;
-import org.camunda.connect.httpclient.soap.SoapHttpRequest;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
According to https://docs.camunda.org/manual/7.21/update/minor/720-to-721/#update-the-client-s-apache-httpclient-to-version-5 there is already some migration towards `httpclient5`.

This PR includes:
* HTTP and SOAP connectors based on httpclient 5.x
* Updated README.md to reflect changes
* Trivial code cleanup

Some details I want to point out:
* `clirr-maven-plugin` complains about incompatible API due to some of my code cleanup. Honestly I do not think that these are issues to be concerned about but overall help the code quality of this project.
* Compatibility in usage of httpclient 5 over 4 should be fine thanks to the abstraction. The only thing that really changed are the configuration options (some got removed, some got renamed, some new were added). Again, I do not think this is a big issue.
* I had to remove some tests due to the config changes (but added new once as well). Further I had to adapt some tests because they did not test properly to begin with.

I'd be happy to discuss any recommendations or changes. 
Once this is merged, I could contribute some more, e.g. migrating to JUnit5 would be a good idea.