### PR TITLE
chore: switch to Sonatype Central Portal deployment (1.6)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.5.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR is part of our [migration](https://github.com/camunda/camunda-release-parent/blob/infra-833-prepare-migration/README.md) to the new Sonatype Central Portal, and upgrades the camunda-bpm-release-parent POM to the latest version.

Sonatype is deprecating the legacy OSSRH Staging API, and the migration affects all Camunda namespaces (io.camunda, org.camunda). Publishing via OSSRH will no longer be possible once the namespaces are migrated.